### PR TITLE
Fport optimisation no data in fport

### DIFF
--- a/draft-ietf-lpwan-schc-over-lorawan.md
+++ b/draft-ietf-lpwan-schc-over-lorawan.md
@@ -310,7 +310,7 @@ confirmed messages.
 
 The LoRaWAN MAC layer features a frame port field in all frames. This field
 (FPort) is 8-bit long and the values from 1 to 223 can be used. It allows
-LoRaWAN network and application to identify data.
+LoRaWAN networks and applications to identify data.
 
 The FPort field is part of the SCHC Packet or the SCHC Fragment, as shown in
 {{Fig-lorawan-schc-payload}}. The SCHC C/D and the SCHC F/R SHALL concatenate

--- a/draft-ietf-lpwan-schc-over-lorawan.md
+++ b/draft-ietf-lpwan-schc-over-lorawan.md
@@ -108,7 +108,7 @@ This section contains a short overview of Static Context Header Compression
 Static Context Header Compression (SCHC) avoids context synchronization, based
 on the fact that the nature of data flows is highly predictable in LPWAN
 networks, some static contexts may be stored on the Device (Dev). The contexts
-must be stored in both ends, and it can either be learned by a provisioning
+MUST be stored in both ends, and it can either be learned by a provisioning
 protocol or by out-of-band means or it can be pre-provisioned, etc. The way the
 context is learned on both sides is out of the scope of this document.
 
@@ -132,18 +132,17 @@ context is learned on both sides is out of the scope of this document.
 
 {{Fig-archi}} represents the architecture for compression/decompression, it is
 based on {{RFC8376}} terminology. The Device is sending applications flows
-using IPv6 or IPv6/UDP protocols. These flow might be fragemented (SCHC F/R),
-and compressed by an Static Context Header Compression Compressor/Decompressor
-(SCHC C/D) to reduce headers size.
-Resulting information is sent on a layer two (L2) frame to a LPWAN Radio
-Network Gateway (RGW) which forwards the frame to a Network Gateway (NGW). The
-NGW sends the data to a SCHC F/R for defragmentation, if required, then C/D for
-decompression which shares the same rules with the device. The SCHC F/R and C/D
-can be located on the Network Gateway (NGW) or in another place as long as a
-tunnel is established between the NGW and the SCHC F/R, then SCHC F/R and
-SCHC C/D. The SCHC C/D in both sides must share the same set of Rules. After
-decompression, the packet can be sent on the Internet to one or several LPWAN
-Application Servers (App).
+using IPv6 or IPv6/UDP protocols. These flow might be compressed by an Static
+Context Header Compression Compressor/Decompressor (SCHC C/D) to reduce headers
+size and fragmented (SCHC F/R).  Resulting information is sent on a layer two
+(L2) frame to a LPWAN Radio Gateway (RGW) which forwards the frame to a Network
+Gateway (NGW). The NGW sends the data to a SCHC F/R for defragmentation, if
+required, then C/D for decompression which shares the same rules with the
+device. The SCHC F/R and C/D can be located on the Network Gateway (NGW) or in
+another place as long as a tunnel is established between the NGW and the SCHC
+F/R, then SCHC F/R and SCHC C/D. The SCHC C/D in both sides MUST share the same
+set of Rules. After decompression, the packet can be sent on the Internet to
+one or several LPWAN Application Servers (App).
 
 The SCHC F/R and SCHC C/D process is bidirectional, so the same principles can
 be applied in the other direction.
@@ -168,7 +167,7 @@ terminology to:
             +-------+     |server |    |server F/R - C/D|
                           +-------+    +----------------+
 ~~~~
-{: #Fig-archi-lorawan title='Architecture'}
+{: #Fig-archi-lorawan title='SCHC Architecture mapped to LoRaWAN'}
 
 
 #LoRaWAN Architecture
@@ -244,24 +243,24 @@ A+C. ClassB and classC are mutually exclusive.
   ClassC end-devices can receive downlinks at any time at the expense of a higher
   power consumption. Battery powered end-devices can only operate in classC for a
   limited amount of time (for example for a firmware upgrade over-the-air).
-  Most of the classC end-devices are main powered (for example Smart Plugs).
+  Most of the classC end-devices are mains powered (for example Smart Plugs).
 
 ## End-Device addressing
 
-LoRaWAN end-devices use a 32 bits network address (devAddr) to communicate with
+LoRaWAN end-devices use a 32-bit network address (devAddr) to communicate with
 the network over-the-air. However, that address might be reused several time
 on the same network at the same time for different end-devices. End-devices using the
 same devAddr are distinguish by the Network Server based on the cryptographic
 signature appended to every single LoRaWAN MAC frame, as all end-devices use
 different security keys.
 To communicate with the SCHC gateway the Network Server MUST identify the
-end-devices by a unique 64bits device ID called the devEUI. Unlike devAddr,
-devEUI is guaranteed to be unique for every single end-device across all
-networks.
+end-devices by a unique 64-bit device identifier called the devEUI. Unlike
+devAddr, devEUI is guaranteed to be unique for every single end-device across
+all networks.
 The devEUI is assigned to the end-device during the manufacturing process by the
 end-device's manufacturer. It is built like an Ethernet MAC address by
 concatenating the manufacturer's IEEE OUI field with a vendor unique number.
-ex: 24bits OUI is concatenated with a 40 bits serial number.
+e.g.: 24-bit OUI is concatenated with a 40-bit serial number.
 The Network Server translates the devAddr into a devEUI in the uplink
 direction and reciprocally on the downlink direction.
 
@@ -322,13 +321,13 @@ transferred from server to device, is called downlink fragmentation session. It
 uses another range of FPorts for data downlink and its associated SCHC control
 uplinks, named FPortsDown in this document.
 
-FPorts can use arbitrary values inside the allowed FPort range and must be
+FPorts can use arbitrary values inside the allowed FPort range and MUST be
 shared by the end-device, the Network Server and SCHC gateway. The uplink and
-downlink SCHC ports must be different. Mechanism to share those FPorts values is
+downlink SCHC ports MUST be different. Mechanism to share those FPorts values is
 out-of-scope of this document.
 
 Application can have multiple fragmentation session between a device and one or
-several SCHC gateways. A set of FPort values is required for each gateway
+several SCHC gateways. A set of FPort values is REQUIRED for each gateway
 instance the device is required to communicate with.
 
 The only uplink messages using the FPortsDown port are the fragmentation SCHC
@@ -348,7 +347,7 @@ SHOULD be reserved to tag packets for which SCHC compression was not possible
 
 The remaining RuleIDs are available for compression. RuleIDs are shared between
 uplink and downlink sessions.  A RuleID not in FPortsUp nor FPortsDown ranges
-means that the fragmentation is not used, thus the packet should be send to C/D
+means that the fragmentation is not used, thus the packet SHOULD be send to C/D
 layer.
 
 ## IID computation
@@ -356,7 +355,8 @@ layer.
 As LoRaWAN network uses unique EUI-64 per end-device, the Interface IDentifier is
 the LoRaWAN DevEUI.
 It is compliant with [RFC4291] and IID starting with binary 000 must enforce
-the 64-bits rule.
+the 64-bit rule.
+
 TODO: Derive IID from DevEUI with privacy constraints ? Ask working group ?
 
 ## Compression {#Comp}
@@ -394,7 +394,7 @@ A LoRaWAN device cannot interleave several fragmented SCHC datagrams. This one
 bit field is used to distinguish two consecutive fragmentation sessions.
 
 _Note_: While it is used to recover faster from transmission errors, it SHALL
-not be considered as the only way to distinguish two fragmentation sessions.
+NOT be considered as the only way to distinguish two fragmentation sessions.
 
 ### Uplink fragmentation: From device to SCHC gateway
 
@@ -425,10 +425,10 @@ fragment.
   If this ACK is not received the end-device sends an all-0 (or an all-1)
   fragment with no payload to request an SCHC ACK retransmission. The
   periodicity between retransmission of the all-0/all-1 fragments is
-  device/application specific and may be different for each device (not
+  device/application specific and MAY be different for each device (not
   specified). The SCHC gateway implements an "inactivity timer". The default
-  recommended duration of this timer is 12 hours. This value is mainly driven
-  by application requirements and may be changed by the application.
+  RECOMMENDED duration of this timer is 12 hours. This value is mainly driven
+  by application requirements and MAY be changed by the application.
 * **Last tile**: Last tile can be carried in the All-1 fragment.
 
 
@@ -535,7 +535,7 @@ fragment.
 As only 1 tile is used, its size can change for each downlink, and will be
 maximum available MTU.
 
-_Note_: The Fpending bit included in LoRaWAN protocol SHOULD not be used for
+_Note_: The Fpending bit included in LoRaWAN protocol SHOULD NOT be used for
 SCHC-over-LoRaWAN protocol. It might be set by the Network Server for other
 purposes in but not SCHC needs.
 
@@ -616,24 +616,24 @@ The device replies with an ACK message to every single fragment received from
 the SCHC gateway (because the window size is 1). Following the reception of a
 FCN=0 fragment (fragment that is not the last fragment of the packet or
 ACK-request, but the end of a window), the device MUST transmit the SCHC ACK
-fragment until it receives the fragment of the next window. The device shall
+fragment until it receives the fragment of the next window. The device SHALL
 transmit up to MAX_ACK_REQUESTS ACK messages before aborting. The device
 should transmit those ACK as soon as possible while taking into consideration
 potential local radio regulation on duty-cycle, to progress the fragmentation
 session as quickly as possible. The ACK bitmap is 1 bit long and is always 1.
 
 Following the reception of a FCN=All-1 fragment (the last fragment of a
-datagram) and if the RCS is correct, the device shall transmit the ACK with
+datagram) and if the RCS is correct, the device SHALL transmit the ACK with
 the "RCS is correct" indicator bit set (C=1). This message might be lost
-therefore the SCHC gateway may request a retransmission of this ACK in the next
+therefore the SCHC gateway MAY request a retransmission of this ACK in the next
 downlink. The device SHALL keep this ACK message in memory until it receives
-a downlink, on SCHC FPortDown from the SCHC gateway different from an
+a downlink, on SCHC FPortsDown from the SCHC gateway different from an
 ACK-request: it indicates that the SCHC gateway has received the ACK message.
 
 Following the reception of a FCN=All-1 fragment (the last fragment of a
-datagram), if all fragments have been received and the RCS is NOT correct,
-the device shall transmit a Receiver-Abort fragment. The device SHALL keep
-this Abort message in memory until it receives a downlink, on SCHC FPortDown,
+datagram), if all fragments have been received and the RCS is not correct,
+the device SHALL transmit a Receiver-Abort fragment. The device SHALL keep
+this Abort message in memory until it receives a downlink, on SCHC FPortsDown,
 from the SCHC gateway different from an ACK-request indicating that the SCHC
 gateway has received the Abort message.  The fragmentation receiver (device)
 does not implement retransmission timer and inactivity timer.
@@ -641,7 +641,7 @@ does not implement retransmission timer and inactivity timer.
 The fragmentation sender (the SCHC gateway) implements an inactivity timer with
 default duration of 12 hours. Once a fragmentation session is started, if the
 SCHC gateway has not received any ACK or Receiver-Abort message 12 hours after
-the last message from the device was received, the SCHC gateway may flush the
+the last message from the device was received, the SCHC gateway MAY flush the
 fragmentation context.  For devices with very low transmission rates
 (example 1 packet a day in normal operation) , that duration may be extended,
 but this is application specific.
@@ -663,7 +663,7 @@ retransmits the last fragment. The SCHC gateway tries retransmitting up to
 MAX_ACK_REQUESTS times before aborting.
 
 Following the reception of a FCN=All-1 fragment (the last fragment of a
-datagram) and if the RCS is correct, the device shall transmit the ACK with the
+datagram) and if the RCS is correct, the device SHALL transmit the ACK with the
 RCS is correct” indicator bit set. If the SCHC gateway receives this ACK, the
 current fragmentation session has succeeded and its context can be cleared.
 
@@ -678,17 +678,17 @@ DTag) fragment indicating that the SCHC gateway has received the ACK message.
 
 Following the reception of a FCN=All-1 fragment (the last fragment of a
 datagram), if all fragments have been received and if the RCS is NOT correct,
-the device shall transmit a Receiver-Abort fragment.  The retransmission
+the device SHALL transmit a Receiver-Abort fragment.  The retransmission
 timer is used by the SCHC gateway (the sender), the optimal value is very much
 application specific but here are some recommended default values.
 For classB end-devices, this timer trigger is a function of the periodicity of the
-classB ping slots. The recommended value is equal to 3 times the classB ping
+classB ping slots. The RECOMMENDED value is equal to 3 times the classB ping
 slot periodicity. For classC end-devices which are nearly constantly receiving,
-the recommended value is 30 seconds. This means that the end-device shall try to
+the RECOMMENDED value is 30 seconds. This means that the end-device shall try to
 transmit the ACK within 30 seconds  of the reception of each fragment.  The
 inactivity timer is implemented by the end-device to flush the context in-case it
 receives nothing from the SCHC gateway over an extended period of time. The
-recommended value is 12 hours for both classB&C end-devices.
+RECOMMENDED value is 12 hours for both classB&C end-devices.
 
 # Security considerations
 

--- a/draft-ietf-lpwan-schc-over-lorawan.md
+++ b/draft-ietf-lpwan-schc-over-lorawan.md
@@ -857,7 +857,7 @@ ruleId, 21 bits residue + 127 bytes payload.
 |   1    |       21 bits       | 127 bytes |
 
 
-The current LoRaWAN MTU is 50 bytes, no FOpts are used by LoRaWAN
+The current LoRaWAN MTU is 51 bytes, no FOpts are used by LoRaWAN
 protocol: 48 bytes are available for SCHC payload + FPort field => it
 has to be fragmented.
 

--- a/draft-ietf-lpwan-schc-over-lorawan.md
+++ b/draft-ietf-lpwan-schc-over-lorawan.md
@@ -221,29 +221,29 @@ and the ones in {{lora-alliance-spec}} is as follows:
 
 ## End-Device classes (A, B, C) and interactions
 
-The LoRaWAN MAC layer supports 3 classes of end-devices named A, B and C.
-All end-devices implement the classA, some end-devices implement classA+B or class
-A+C. ClassB and classC are mutually exclusive.
+The LoRaWAN MAC layer supports 3 classes of end-devices named A, B and C.  All
+end-devices implement the Class A, some end-devices MAY implement Class B or
+class C. Class B and Class C are mutually exclusive.
 
-* **ClassA**: The classA is the simplest class of end-devices. The end-device is
+* **Class A**: The Class A is the simplest class of end-devices. The end-device is
   allowed to transmit at any time, randomly selecting a communication channel.
   The network may reply with a downlink in one of the 2 receive windows
   immediately following the uplinks. Therefore, the network cannot initiate a
   downlink, it has to wait for the next uplink from the end-device to get a
-  downlink opportunity. The classA is the lowest power end-device class.
-* **ClassB**: classB end-devices implement all the functionalities of classA
+  downlink opportunity. The Class A is the lowest power end-device class.
+* **Class B**: Class B end-devices implement all the functionalities of Class A
   end-devices, but also schedule periodic listen windows. Therefore, as opposed the
-  classA end-devices, classB end-devices can receive downlink that are initiated by the
+  Class A end-devices, Class B end-devices can receive downlink that are initiated by the
   network and not following an uplink. There is a trade-off between the
-  periodicity of those scheduled classB listen windows and the power
+  periodicity of those scheduled Class B listen windows and the power
   consumption of the end-device. The lower the downlink latency, the higher the
   power consumption.
-* **ClassC**: classC end-devices implement all the functionalities of classA
+* **Class C**: Class C end-devices implement all the functionalities of Class A
   end-devices, but keep their receiver open whenever they are not transmitting.
-  ClassC end-devices can receive downlinks at any time at the expense of a higher
-  power consumption. Battery powered end-devices can only operate in classC for a
+  Class C end-devices can receive downlinks at any time at the expense of a higher
+  power consumption. Battery powered end-devices can only operate in Class C for a
   limited amount of time (for example for a firmware upgrade over-the-air).
-  Most of the classC end-devices are mains powered (for example Smart Plugs).
+  Most of the Class C end-devices are mains powered (for example Smart Plugs).
 
 ## End-Device addressing
 
@@ -602,14 +602,14 @@ session.
 {: #Fig-fragmentation-downlink-header-abort title='Receiver-Abort packet (following an all-1 packet with incorrect RCS).'}
 
 
-Class A and classB&C end-devices do not manage retransmissions and timers in the
-same way.
+Class A and Class B/Class C end-devices do not manage retransmissions and
+timers in the same way.
 
-#### ClassA end-devices
+#### Class A end-devices
 
 Class A end-devices can only receive in an RX slot following the transmission of an
 uplink.  Therefore there cannot be a concept of "retransmission timer" for an
-SCHC gateway. The SCHC gateway cannot initiate communication to a classA
+SCHC gateway. The SCHC gateway cannot initiate communication to a Class A
 end-device.
 
 The device replies with an ACK message to every single fragment received from
@@ -647,15 +647,15 @@ fragmentation context.  For devices with very low transmission rates
 but this is application specific.
 
 
-#### Class B or C end-devices
+#### Class B or Class C end-devices
 
-Class B&C end-devices can receive in scheduled RX slots or in RX slots following
-the transmission of an uplink. The device replies with an ACK message to
-every single fragment received from the SCHC gateway (because the window size
-is 1). Following the reception of a FCN=0 fragment (fragment that is not the
-last fragment of the packet or ACK-request), the device MUST always transmit
-the corresponding SCHC ACK message even if that fragment has already been
-received.
+Class B and Class C end-devices can receive in scheduled RX slots or in RX
+slots following the transmission of an uplink. The device replies with an ACK
+message to every single fragment received from the SCHC gateway (because the
+window size is 1). Following the reception of a FCN=0 fragment (fragment that
+is not the last fragment of the packet or ACK-request), the device MUST always
+transmit the corresponding SCHC ACK message even if that fragment has already
+been received.
 The ACK bitmap is 1 bit long and is always 1. If the SCHC gateway receives this
 ACK, it proceeds to send the next window fragment. If the retransmission timer
 elapses and the SCHC gateway has not received the ACK of the current window it
@@ -681,14 +681,14 @@ datagram), if all fragments have been received and if the RCS is NOT correct,
 the device SHALL transmit a Receiver-Abort fragment.  The retransmission
 timer is used by the SCHC gateway (the sender), the optimal value is very much
 application specific but here are some recommended default values.
-For classB end-devices, this timer trigger is a function of the periodicity of the
-classB ping slots. The RECOMMENDED value is equal to 3 times the classB ping
-slot periodicity. For classC end-devices which are nearly constantly receiving,
+For Class B end-devices, this timer trigger is a function of the periodicity of the
+Class B ping slots. The RECOMMENDED value is equal to 3 times the Class B ping
+slot periodicity. For Class C end-devices which are nearly constantly receiving,
 the RECOMMENDED value is 30 seconds. This means that the end-device shall try to
 transmit the ACK within 30 seconds  of the reception of each fragment.  The
 inactivity timer is implemented by the end-device to flush the context in-case it
 receives nothing from the SCHC gateway over an extended period of time. The
-RECOMMENDED value is 12 hours for both classB&C end-devices.
+RECOMMENDED value is 12 hours for both Class B and Class C end-devices.
 
 # Security considerations
 

--- a/draft-ietf-lpwan-schc-over-lorawan.md
+++ b/draft-ietf-lpwan-schc-over-lorawan.md
@@ -387,7 +387,6 @@ as per [](#Fig-fragmentation-receiver-abort).
 SCHC C/D RuleID size SHOULD be 8 bits to fit the LoRaWAN FPort field. RuleIDs
 matching FPortsUp and FPortsDown are reserved for SCHC Fragmentation.
 
-
 ## Fragmentation {#Frag}
 
 The L2 word size used by LoRaWAN is 1 byte (8 bits).
@@ -402,11 +401,9 @@ The fragmentation parameters are different for uplink and downlink
 fragmentation sessions and are successively described in the next sections.
 
 ## DTag
-A LoRaWAN device cannot interleave several fragmented SCHC datagrams. This one
-bit field is used to distinguish two consecutive fragmentation sessions.
 
-_Note_: While it is used to recover faster from transmission errors, it SHALL
-NOT be considered as the only way to distinguish two fragmentation sessions.
+A LoRaWAN device cannot interleave several fragmented SCHC datagrams. This
+field is not used and its size is 0.
 
 ### Uplink fragmentation: From device to SCHC gateway
 
@@ -419,7 +416,7 @@ fragment as per [](#Fig-fragmentation-receiver-abort).
 * SCHC header is two bytes, including FPort byte.
 * **RuleID**: Recommended size is 8 bits in SCHC header.
 * **SCHC fragmentation reliability mode**: `ACK-on-Error`
-* **DTag**: size is 1 bit.
+* **DTag**: Size is 0 bit, not used
 * **FCN**: The FCN field is encoded on N = 6 bits, so WINDOW_SIZE = 64 tiles
   are allowed in a window
 * **Window index**: encoded on W = 2 bits. So 4 windows are available.
@@ -450,11 +447,11 @@ LoRaWAN payload. MTU is: _4 windows * 64 tiles * 5 bytes per tile = 1280 bytes_
 
 ~~~~
 
-| FPort  |  LoRaWAN payload                  |
-+ ------ + --------------------------------- +
-| RuleID | DTag  | W      | FCN    | Payload |
-+ ------ + ----- + ------ + ------ + ------- +
-| 8 bits | 1 bit | 2 bits | 7 bits |         |
+| FPort  |  LoRaWAN payload          |
++ ------ + ------------------------- +
+| RuleID |   W    | FCN    | Payload |
++ ------ + ------ + ------ + ------- +
+| 8 bits | 2 bits | 7 bits |         |
 
 ~~~~
 {: #Fig-fragmentation-header-long-all0 title='All fragment except the last one. SCHC header size is 18 bits, including LoRaWAN FPort.'}
@@ -464,11 +461,11 @@ LoRaWAN payload. MTU is: _4 windows * 64 tiles * 5 bytes per tile = 1280 bytes_
 
 ~~~~
 
-| FPort  | LoRaWAN payload                                          |
-+ ------ + -------------------------------------------------------- +
-| RuleID | DTag  | W      | FCN=All-1 | RCS     | Payload           |
-+ ------ + ----- + ------ + --------- + ------- + ----------------- +
-| 8 bits | 1 bit | 2 bits | 7 bits    | 32 bits | Last tile, if any |
+| FPort  | LoRaWAN payload                                  |
++ ------ + ------------------------------------------------ +
+| RuleID |   W    | FCN=All-1 |  RCS    | Payload           |
++ ------ + ------ + --------- + ------- + ----------------- +
+| 8 bits | 2 bits | 7 bits    | 32 bits | Last tile, if any |
 
 ~~~~
 {: #Fig-fragmentation-header-all1 title='All-1 fragment detailed format for the last fragment.'}
@@ -477,11 +474,11 @@ LoRaWAN payload. MTU is: _4 windows * 64 tiles * 5 bytes per tile = 1280 bytes_
 
 ~~~~
 
-| FPort  | LoRaWAN payload                                   |
-+ ------ + ------------------------------------------------- +
-| RuleID | DTag  | W     | C     | Encoded bitmap (if C = 0) |
-+ ------ + ----- + ----- + ----- + ------------------------- +
-| 8 bits | 1 bit | 2 bit | 1 bit | 0 to 127 bits             |
+| FPort  | LoRaWAN payload                           |
++ ------ + ----------------------------------------- +
+| RuleID |   W   | C     | Encoded bitmap (if C = 0) |
++ ------ + ----- + ----- + ------------------------- +
+| 8 bits | 2 bit | 1 bit | 0 to 127 bits             |
 
 ~~~~
 {: #Fig-fragmentation-header-long-schc-ack title='SCHC formats, failed RCS check.'}
@@ -491,12 +488,12 @@ LoRaWAN payload. MTU is: _4 windows * 64 tiles * 5 bytes per tile = 1280 bytes_
 
 ~~~~
 
-| FPort  | LoRaWAN payload                                     |
-+ ------ + --------------------------------------------------- +
-| RuleID | DTag  | W = b'11 | C = 1 | b'1111 | 0xFF (all 1's)  |
-+ ------ + ----- + -------- + ------+------- + ----------------+
-| 8 bits | 1 bit | 2 bits   | 1 bit | 4 bits | 8 bits          |
-                     next L2 Word boundary ->| <-- L2 Word --> |
+| FPort  | LoRaWAN payload                             |
++ ------ + ------------------------------------------- +
+| RuleID | W = b'11 | C = 1 | b'1111 | 0xFF (all 1's)  |
++ ------ + -------- + ------+------- + ----------------+
+| 8 bits |  2 bits  | 1 bit | 4 bits | 8 bits          |
+             next L2 Word boundary ->| <-- L2 Word --> |
 
 ~~~~
 {: #Fig-fragmentation-receiver-abort title='Receiver-Abort format.'}
@@ -506,11 +503,11 @@ LoRaWAN payload. MTU is: _4 windows * 64 tiles * 5 bytes per tile = 1280 bytes_
 
 ~~~~
 
-| FPort  | LoRaWAN payload                  |
-+------- +--------------------------------- +
-| RuleID | DTag  | W      | FCN = b'0000000 |
-+ ------ + ----- + ------ + --------------- +
-| 8 bits | 1 bit | 2 bits | 7 bits          |
+| FPort  | LoRaWAN payload          |
++------- +------------------------- +
+| RuleID | W      | FCN = b'0000000 |
++ ------ + ------ + --------------- +
+| 8 bits | 2 bits | 7 bits          |
 
 
 ~~~~
@@ -528,7 +525,7 @@ fragment as described in {{Fig-lorawan-schc-payload}}.
 * **SCHC fragmentation reliability mode**: ACK-Always.
 * **RuleID**: Recommended size is 8 bits in SCHC header.
 * **Window index**: encoded on W=1 bit, as per {{I-D.ietf-lpwan-ipv6-static-context-hc}}.
-* **DTag**: Not used, so its size is 0 bit.
+* **DTag**: Size is 0 bit, not used
 * **FCN**: The FCN field is encoded on N=1 bits, so WINDOW_SIZE = 1 tile
   (FCN=All-1 is reserved for SCHC).
 * **RCS calculation algorithm**: CRC32 using 0xEDB88320 (i.e. the reverse
@@ -669,10 +666,6 @@ If the retransmission timer elapses and the SCHC gateway has not received the
 SCHC ACK it retransmits the last fragment with the payload (not an ACK-request
 without payload). The SCHC gateway tries retransmitting up to MAX_ACK_REQUESTS
 times before aborting.
-
-The device SHALL keep the SCHC ACK message in memory until it receives a
-downlink from the SCHC gateway different from the last (FCN>0 and different
-DTag) fragment indicating that the SCHC gateway has received the ACK message.
 
 Following the reception of a FCN=All-1 fragment (the last fragment of a
 datagram), if all fragments have been received and if the RCS is NOT correct,

--- a/draft-ietf-lpwan-schc-over-lorawan.md
+++ b/draft-ietf-lpwan-schc-over-lorawan.md
@@ -750,8 +750,8 @@ going through SCHC, no fragmentation required
 ~~~~
 
 An applicative payload of 78 bytes is passed to SCHC compression layer
-using rule 1, allowing to compress it to 40 bytes and 5 bits: 21 bits
-residue + 38 bytes payload.
+using rule 1, allowing to compress it to 40 bytes and 5 bits: 1 byte ruleId,
+21 bits residue + 37 bytes payload.
 
 
 | RuleID | Compression residue |  Payload  | Padding=b'000 |
@@ -764,11 +764,11 @@ LoRaWAN protocol: 49 bytes are available for SCHC payload; no need for
 fragmentation. The payload will be transmitted through FPort = 1
 
 
-|     LoRaWAN Header                   | 51 bytes LoRaWAN payload                        |
-+ ------------------------------------ + ----------------------------------------------- +
-|                | RuleID=20 |  FOpts  | Compression residue |  Payload  | Padding=b'000 |
-+ -------------- + --------- + ------- + ------------------- + --------- + ------------- +
-|       XXXX     |     1     | 2 bytes |       21 bits       |  38 bytes |    3 bits     |
+| LoRaWAN Header                      | LoRaWAN payload (40 bytes)                      |
++ ----------------------------------- + ----------------------------------------------- +
+|                |  FOpts  | RuleID=1 | Compression residue |  Payload  | Padding=b'000 |
++ -------------- + ------- + -------- + ------------------- + --------- + ------------- +
+|       XXXX     | 2 bytes | 1 byte   |       21 bits       |  37 bytes |    3 bits     |
 
 ~~~~
 {: #Fig-example-uplink-no-fragmentation title='Uplink example: compression without fragmentation'}
@@ -794,11 +794,11 @@ The current LoRaWAN MTU is 11 bytes, although 2 bytes FOpts are used by
 LoRaWAN protocol: 9 bytes are available for SCHC payload + 1 byte FPort field.
 SCHC header is 2 bytes (including FPort) so 1 tile is send in first fragment.
 
-| LoRaWAN Header                        | LoRaWAN payload (6 bytes)  |
-+ ------------------------------------- + -------------------------- +
-|                | RuleID=20  |  FOpts  |   W   |  FCN   | 1 tile    |
-+ -------------- + ---------- + ------- + ----- + ------ + --------- +
-|       XXXX     | 1 byte     | 2 bytes | 0   0 |   62   | 5 bytes   |
+| LoRaWAN Header                        | LoRaWAN payload (6 bytes) |
++ ------------------------------------- + ------------------------- +
+|                |  FOpts  | RuleID=20  |   W   |  FCN   |  1 tile  |
++ -------------- + ------- + ---------- + ----- + ------ + -------- +
+|       XXXX     | 2 bytes | 1 byte     | 0   0 |   62   | 5 bytes  |
 
 
 Content of the tile is:
@@ -882,11 +882,11 @@ The receiver answers with an SCHC ACK
 The second downlink is send, two FOpts:
 
 
-| LoRaWAN Header                        | LoRaWAN payload (48 bytes)                     |
-+ ------------------------------------- + ---------------------------------------------- +
-|                | RuleID=21  |  FOpts  |  W  |  FCN |    1 tile      | Padding=b'000000 |
-+ -------------- + ---------- + ------- + --- + ---- + -------------- + ---------------- +
-|       XXXX     | 1 byte     | 2 bytes |  1  |   0  |   47 bytes     |      6 bits      |
+| LoRaWAN Header                        | LoRaWAN payload (48 bytes)                    |
++ ------------------------------------- + -------------------------- + ---------------- +
+|                |  FOpts  | RuleID=21  |  W  | FCN |    1 tile      | Padding=b'000000 |
++ -------------- + ------- + ---------- + --- + --- + -------------- + ---------------- +
+|       XXXX     | 2 bytes | 1 byte     |  1  |  0  |   47 bytes     |      6 bits      |
 
 
 The receiver answers with an SCHC ACK

--- a/draft-ietf-lpwan-schc-over-lorawan.md
+++ b/draft-ietf-lpwan-schc-over-lorawan.md
@@ -336,38 +336,39 @@ uplinks, named FPortsDown in this document.
 
 FPorts can use arbitrary values inside the allowed FPort range and MUST be
 shared by the end-device, the Network Server and SCHC gateway. The uplink and
-downlink fragmentation FPorts MUST be different. Mechanism to share those FPorts
-values is out-of-scope of this document. In order to improve interoperability,
-it is RECOMMENDED to use:
+downlink fragmentation FPorts MUST be different.
 
-* RuleID = b'TBC (8-bit) for uplink fragmentation, named FPortUp
-* RuleID = b'TBC (8-bit) for downlink fragmentation, named FPortDown
-* 8-bit RuleIDs for compression, in the range [1;223] except values previously
-  defined RuleID fragmentation.
+## Rule ID management
 
-Application can have multiple fragmentation sessions between a device and one or
-several SCHC gateways. A set of FPort values is REQUIRED for each gateway
-instance the device is required to communicate with.
+RuleID minimum length MUST be minimum 8-bits, and RECOMMENDED length is 8-bits.
+RuleID MSB is encoded in the LoRaWAN FPort as described in
+{{Fig-lorawan-schc-payload}}. LoRaWAN supports up to 223 application FPorts in
+range [1;223], it implies that RuledID MSB SHOULD be insidethis range.
+Application MAY reserve some FPort values for other needs.
+
+A RuleID SHOULD be reserved to tag packets for which SCHC compression was not
+possible (no matching Rule was found). RuleIDs FPortsUp and FPortsDown are
+reserved for fragmentation, in order to improve interoperability RECOMMENDED
+values are:
+
+* RuleID = 20 (8-bit) for uplink fragmentation, named FPortUp
+* RuleID = 21 (8-bit) for downlink fragmentation, named FPortDown
+* RuleID = 22 (8-bit) for which SCHC compression was not possible
+
+The remaining RuleIDs are available for compression. RuleIDs are shared between
+uplink and downlink sessions.  A RuleID not FPortsUp or FPortsDown means that
+the fragmentation is not used, thus the packet SHOULD be send to C/D layer.
 
 The only uplink messages using the FPortsDown port are the fragmentation SCHC
 control messages of a downlink fragmentation session (ex ACKs). Similarly, the
 only downlink messages using the FPortsUp ports are the fragmentation SCHC
 control messages of an uplink fragmentation session.
 
-## Rule ID management
+Application can have multiple fragmentation sessions between a device and one
+or several SCHC gateways.  A set of FPort values is REQUIRED for each gateway
+instance the device is required to communicate with.
 
-RuleID is encoded in the LoRaWAN FPort for SCHC C/D. LoRaWAN supports up to 222
-application FPorts in range [1;223]. SCHC-over-LoRaWAN defines FPort ranges
-dedicated to SCHC F/R. Application MAY reserve some FPort values for other needs.
-A RuleID SHOULD be reserved to tag packets for which SCHC compression was not
-possible (no matching Rule was found), the RECOMMANDED value is b'TBC (8-bit).
-
-RuleIDs FPortsUp and FPortsDown are reserved for fragmentation.
-
-The remaining RuleIDs are available for compression. RuleIDs are shared between
-uplink and downlink sessions.  A RuleID not FPortsUp nr FPortsDown means that
-the fragmentation is not used, thus the packet SHOULD be send to C/D
-layer.
+Mechanism to share those RuleID values is out-of-scope of this document
 
 ## IID computation
 
@@ -416,7 +417,7 @@ SCHC F/R MUST concatenate FPort and LoRaWAN payload to retrieve the SCHC
 fragment as per [](#Fig-fragmentation-receiver-abort).
 
 * SCHC header is two bytes, including FPort byte.
-* **RuleID**: size is 8 bits in SCHC header.
+* **RuleID**: Recommended size is 8 bits in SCHC header.
 * **SCHC fragmentation reliability mode**: `ACK-on-Error`
 * **DTag**: size is 1 bit.
 * **FCN**: The FCN field is encoded on N = 7 bits, so WINDOW_SIZE = 127 tiles
@@ -525,7 +526,7 @@ SCHC F/R MUST concatenate FPort and LoRaWAN payload to retrieve the SCHC
 fragment as described in {{Fig-lorawan-schc-payload}}.
 
 * **SCHC fragmentation reliability mode**: ACK-Always.
-* **RuleID**: size is 8 bits in SCHC header.
+* **RuleID**: Recommended size is 8 bits in SCHC header.
 * **Window index**: encoded on W=1 bit, as per {{I-D.ietf-lpwan-ipv6-static-context-hc}}.
 * **DTag**: Not used, so its size is 0 bit.
 * **FCN**: The FCN field is encoded on N=1 bits, so WINDOW_SIZE = 1 tile

--- a/draft-ietf-lpwan-schc-over-lorawan.md
+++ b/draft-ietf-lpwan-schc-over-lorawan.md
@@ -405,6 +405,10 @@ fragmentation sessions and are successively described in the next sections.
 A LoRaWAN device cannot interleave several fragmented SCHC datagrams. This
 field is not used and its size is 0.
 
+## Padding
+
+All padding bits SHOULD be 0.
+
 ### Uplink fragmentation: From device to SCHC gateway
 
 In that case the device is the fragmentation transmitter, and the SCHC gateway

--- a/draft-ietf-lpwan-schc-over-lorawan.md
+++ b/draft-ietf-lpwan-schc-over-lorawan.md
@@ -862,16 +862,16 @@ protocol: 48 bytes are available for SCHC payload + FPort field => it
 has to be fragmented.
 
 
-| LoRaWAN Header    | LoRaWAN payload (50 bytes)                    |
+| LoRaWAN Header    | LoRaWAN payload (51 bytes)                    |
 + ---- + ---------- + --------------------------------------------- +
 |      | RuleID=21  |  W  | FCN |     1 tile     | Padding=b'000000 |
 + ---- + ---------- + --- + --- + -------------- + ---------------- +
-| XXXX | 1 byte     |  0  |  0  |    49 bytes    |      6 bits      |
+| XXXX | 1 byte     |  0  |  0  |    50 bytes    |      6 bits      |
 
 Content of the tile is:
 | RuleID | Compression residue |        Payload     |
 + ------ + ------------------- + ------------------ +
-|   1    |       21 bits       | 45 bytes + 3 bits  |
+|   1    |       21 bits       | 46 bytes + 3 bits  |
 
 
 The receiver answers with an SCHC ACK
@@ -886,11 +886,11 @@ The receiver answers with an SCHC ACK
 The second downlink is send, two FOpts:
 
 
-| LoRaWAN Header              | LoRaWAN payload (48 bytes)            |
+| LoRaWAN Header              | LoRaWAN payload (49 bytes)            |
 + --------------------------- + ------------------ + ---------------- +
 |      |  FOpts  | RuleID=21  | W | FCN | 1 tile   | Padding=b'000000 |
 + ---- + ------- + ---------- + - + --- + -------- + ---------------- +
-| XXXX | 2 bytes | 1 byte     | 1 |  0  | 47 bytes |      6 bits      |
+| XXXX | 2 bytes | 1 byte     | 1 |  0  | 48 bytes |      6 bits      |
 
 
 The receiver answers with an SCHC ACK

--- a/draft-ietf-lpwan-schc-over-lorawan.md
+++ b/draft-ietf-lpwan-schc-over-lorawan.md
@@ -420,14 +420,14 @@ fragment as per [](#Fig-fragmentation-receiver-abort).
 * **RuleID**: Recommended size is 8 bits in SCHC header.
 * **SCHC fragmentation reliability mode**: `ACK-on-Error`
 * **DTag**: size is 1 bit.
-* **FCN**: The FCN field is encoded on N = 7 bits, so WINDOW_SIZE = 127 tiles
-  are allowed in a window (FCN=All-1 is reserved for SCHC).
+* **FCN**: The FCN field is encoded on N = 6 bits, so WINDOW_SIZE = 64 tiles
+  are allowed in a window
 * **Window index**: encoded on W = 2 bits. So 4 windows are available.
 * **RCS calculation algorithm**: CRC32 using 0xEDB88320 (i.e. the reverse
   representation of the polynomial used e.g. in the Ethernet standard
   [RFC3385]) as suggested in {{I-D.ietf-lpwan-ipv6-static-context-hc}}.
 * **MAX_ACK_REQUESTS**: 8
-* **Tile**: size is 3 bytes (24 bits)
+* **Tile**: size is 5 bytes
 * **Retransmission and inactivity timers**:
   LoRaWAN end-devices do not implement a "retransmission timer". At the end of
   a window or a fragmentation session, corresponding ACK(s) is (are)
@@ -444,7 +444,7 @@ fragment as per [](#Fig-fragmentation-receiver-abort).
 
 With this set of parameters, the SCHC fragment header is 18 bits,
 including FPort; payload overhead will be 10 bits as FPort is already a part of
-LoRaWAN payload. MTU is: _4 windows * 127 tiles * 3 bytes per tile = 1524 bytes_
+LoRaWAN payload. MTU is: _4 windows * 64 tiles * 5 bytes per tile = 1280 bytes_
 
 **Regular fragments**
 

--- a/draft-ietf-lpwan-schc-over-lorawan.md
+++ b/draft-ietf-lpwan-schc-over-lorawan.md
@@ -29,6 +29,13 @@ author:
   country: France
   email: ivaylo@ackl.io
   role: editor
+- ins: J. Catalano
+  name: Julien Catalano
+  org: Kerlink
+  street: 1 rue Jacqueline Auriol
+  city: 35235 Thorigné-Fouillard
+  country: France
+  email: j.catalano@kerlink.fr
 normative:
   RFC2119:
   RFC4944:
@@ -715,13 +722,6 @@ Contributors ordered by family name.
   city: 91120 PALAISEAU
   country: FRANCE
   email: vincent.audebert@edf.fr
-- ins: J. Catalano
-  name: Julien Catalano
-  org: Kerlink
-  street: 1 rue Jacqueline Auriol
-  city: 35235 Thorigné-Fouillard
-  country: France
-  email: j.catalano@kerlink.fr
 - ins: M. Coracin
   name: Michael Coracin
   org: Semtech

--- a/draft-ietf-lpwan-schc-over-lorawan.md
+++ b/draft-ietf-lpwan-schc-over-lorawan.md
@@ -160,19 +160,20 @@ Server or any third party software. {{Fig-archi}} can be map in LoRaWAN
 terminology to:
 
 ~~~~
-        Dev                                                         App
-+----------------+                                          +----+ +----+ +----+
-| App1 App2 App3 |                                          |App1| |App2| |App3|
-|                |                                          |    | |    | |    |
-|       UDP      |                                          |UDP | |UDP | |UDP |
-|      IPv6      |                                          |IPv6| |IPv6| |IPv6|
-|                |                                          |    | |    | |    |
-|SCHC C/D and F/R|                                          |    | |    | |    |
-+--------+-------+                                          +----+ +----+ +----+
-         |  +-------+     +-------+    +----------------+     .      .      .
-         +~ |Gateway| === |Network| == |Application     |...... Internet ....
-            +-------+     |server |    |server F/R - C/D|
-                          +-------+    +----------------+
+       Dev                                                  App
++--------------+                                    +----+ +----+ +----+
+|App1 App2 App3|                                    |App1| |App2| |App3|
+|              |                                    |    | |    | |    |
+|      UDP     |                                    |UDP | |UDP | |UDP |
+|     IPv6     |                                    |IPv6| |IPv6| |IPv6|
+|              |                                    |    | |    | |    |
+|SCHC C/D & F/R|                                    |    | |    | |    |
++-------+------+                                    +----+ +----+ +----+
+        |  +-------+     +-------+    +-----------+    .      .      .
+        +~ |Gateway| === |Network| == |Application|..... Internet ....
+           +-------+     |server |    |server     |
+                         +-------+    | F/R - C/D |
+                                      +-----------+
 ~~~~
 {: #Fig-archi-lorawan title='SCHC Architecture mapped to LoRaWAN'}
 
@@ -327,12 +328,12 @@ as a part of the ruleId field.
 {: #Fig-lorawan-schc-payload title='SCHC payload in LoRaWAN'}
 
 A fragmentation session with application payload transferred from device to
-server, is called uplink fragmentation session. It uses a range of FPorts for
-data uplink and its associated SCHC control downlinks, named FPortsUp in this
-document. The other way, a fragmentation session with application payload
-transferred from server to device, is called downlink fragmentation session. It
-uses another range of FPorts for data downlink and its associated SCHC control
-uplinks, named FPortsDown in this document.
+server, is called uplink fragmentation session. It uses a FPort for data uplink
+and its associated SCHC control downlinks, named FPortUp in this document. The
+other way, a fragmentation session with application payload transferred from
+server to device, is called downlink fragmentation session. It uses another
+FPort for data downlink and its associated SCHC control uplinks, named FPortDown
+in this document.
 
 FPorts can use arbitrary values inside the allowed FPort range and MUST be
 shared by the end-device, the Network Server and SCHC gateway. The uplink and
@@ -340,14 +341,14 @@ downlink fragmentation FPorts MUST be different.
 
 ## Rule ID management
 
-RuleID minimum length MUST be minimum 8-bits, and RECOMMENDED length is 8-bits.
+RuleID minimum length MUST be 8 bits, and RECOMMENDED length is 8 bits.
 RuleID MSB is encoded in the LoRaWAN FPort as described in
 {{Fig-lorawan-schc-payload}}. LoRaWAN supports up to 223 application FPorts in
-range [1;223], it implies that RuledID MSB SHOULD be insidethis range.
+range [1;223], it implies that RuledID MSB SHOULD be inside this range.
 Application MAY reserve some FPort values for other needs.
 
 A RuleID SHOULD be reserved to tag packets for which SCHC compression was not
-possible (no matching Rule was found). RuleIDs FPortsUp and FPortsDown are
+possible (no matching Rule was found). RuleIDs FPortUp and FPortDown are
 reserved for fragmentation, in order to improve interoperability RECOMMENDED
 values are:
 
@@ -356,19 +357,19 @@ values are:
 * RuleID = 22 (8-bit) for which SCHC compression was not possible
 
 The remaining RuleIDs are available for compression. RuleIDs are shared between
-uplink and downlink sessions.  A RuleID not FPortsUp or FPortsDown means that
+uplink and downlink sessions.  A RuleID not FPortUp or FPortDown means that
 the fragmentation is not used, thus the packet SHOULD be send to C/D layer.
 
-The only uplink messages using the FPortsDown port are the fragmentation SCHC
+The only uplink messages using the FPortDown port are the fragmentation SCHC
 control messages of a downlink fragmentation session (ex ACKs). Similarly, the
-only downlink messages using the FPortsUp ports are the fragmentation SCHC
+only downlink messages using the FPortUp port are the fragmentation SCHC
 control messages of an uplink fragmentation session.
 
 Application can have multiple fragmentation sessions between a device and one
 or several SCHC gateways.  A set of FPort values is REQUIRED for each gateway
 instance the device is required to communicate with.
 
-Mechanism to share those RuleID values is out-of-scope of this document
+Mechanism to share those RuleID values is out-of-scope of this document.
 
 ## IID computation
 
@@ -379,13 +380,17 @@ the 64-bit rule.
 
 TODO: Derive IID from DevEUI with privacy constraints ? Ask working group ?
 
+## Padding
+
+All padding bits MUST be 0.
+
 ## Compression {#Comp}
 
 SCHC C/D MUST concatenate FPort and LoRaWAN payload to retrieve the SCHC packet
-as per [](#Fig-fragmentation-receiver-abort).
+as per {{Fig-lorawan-schc-payload}}.
 
 SCHC C/D RuleID size SHOULD be 8 bits to fit the LoRaWAN FPort field. RuleIDs
-matching FPortsUp and FPortsDown are reserved for SCHC Fragmentation.
+matching FPortUp and FPortDown are reserved for SCHC Fragmentation.
 
 ## Fragmentation {#Frag}
 
@@ -400,14 +405,10 @@ moment.
 The fragmentation parameters are different for uplink and downlink
 fragmentation sessions and are successively described in the next sections.
 
-## DTag
+### DTag
 
 A LoRaWAN device cannot interleave several fragmented SCHC datagrams. This
 field is not used and its size is 0.
-
-## Padding
-
-All padding bits SHOULD be 0.
 
 ### Uplink fragmentation: From device to SCHC gateway
 
@@ -415,7 +416,7 @@ In that case the device is the fragmentation transmitter, and the SCHC gateway
 the fragmentation receiver.
 A single fragmentation rule is defined.
 SCHC F/R MUST concatenate FPort and LoRaWAN payload to retrieve the SCHC
-fragment as per [](#Fig-fragmentation-receiver-abort).
+fragment as per {{Fig-lorawan-schc-payload}}.
 
 * SCHC header is two bytes, including FPort byte.
 * **RuleID**: Recommended size is 8 bits in SCHC header.
@@ -443,8 +444,8 @@ fragment as per [](#Fig-fragmentation-receiver-abort).
   by application requirements and MAY be changed by the application.
 * **Last tile**: Last tile can be carried in the All-1 fragment.
 
-With this set of parameters, the SCHC fragment header is 18 bits,
-including FPort; payload overhead will be 10 bits as FPort is already a part of
+With this set of parameters, the SCHC fragment header is 16 bits,
+including FPort; payload overhead will be 8 bits as FPort is already a part of
 LoRaWAN payload. MTU is: _4 windows * 64 tiles * 5 bytes per tile = 1280 bytes_
 
 **Regular fragments**
@@ -455,10 +456,10 @@ LoRaWAN payload. MTU is: _4 windows * 64 tiles * 5 bytes per tile = 1280 bytes_
 + ------ + ------------------------- +
 | RuleID |   W    | FCN    | Payload |
 + ------ + ------ + ------ + ------- +
-| 8 bits | 2 bits | 7 bits |         |
+| 8 bits | 2 bits | 6 bits |         |
 
 ~~~~
-{: #Fig-fragmentation-header-long-all0 title='All fragment except the last one. SCHC header size is 18 bits, including LoRaWAN FPort.'}
+{: #Fig-fragmentation-header-long-all0 title='All fragment except the last one. SCHC header size is 16 bits, including LoRaWAN FPort.'}
 
 
 **Last fragment (All-1)**
@@ -469,7 +470,7 @@ LoRaWAN payload. MTU is: _4 windows * 64 tiles * 5 bytes per tile = 1280 bytes_
 + ------ + ------------------------------------------------ +
 | RuleID |   W    | FCN=All-1 |  RCS    | Payload           |
 + ------ + ------ + --------- + ------- + ----------------- +
-| 8 bits | 2 bits | 7 bits    | 32 bits | Last tile, if any |
+| 8 bits | 2 bits | 6 bits    | 32 bits | Last tile, if any |
 
 ~~~~
 {: #Fig-fragmentation-header-all1 title='All-1 fragment detailed format for the last fragment.'}
@@ -492,12 +493,12 @@ LoRaWAN payload. MTU is: _4 windows * 64 tiles * 5 bytes per tile = 1280 bytes_
 
 ~~~~
 
-| FPort  | LoRaWAN payload                             |
-+ ------ + ------------------------------------------- +
-| RuleID | W = b'11 | C = 1 | b'1111 | 0xFF (all 1's)  |
-+ ------ + -------- + ------+------- + ----------------+
-| 8 bits |  2 bits  | 1 bit | 4 bits | 8 bits          |
-             next L2 Word boundary ->| <-- L2 Word --> |
+| FPort  | LoRaWAN payload                              |
++ ------ + -------------------------------------------- +
+| RuleID | W = b'11 | C = 1 | b'11111 | 0xFF (all 1's)  |
++ ------ + -------- + ------+-------- + ----------------+
+| 8 bits |  2 bits  | 1 bit | 5 bits  | 8 bits          |
+              next L2 Word boundary ->| <-- L2 Word --> |
 
 ~~~~
 {: #Fig-fragmentation-receiver-abort title='Receiver-Abort format.'}
@@ -509,9 +510,9 @@ LoRaWAN payload. MTU is: _4 windows * 64 tiles * 5 bytes per tile = 1280 bytes_
 
 | FPort  | LoRaWAN payload          |
 +------- +------------------------- +
-| RuleID | W      | FCN = b'0000000 |
+| RuleID | W      | FCN = b'000000  |
 + ------ + ------ + --------------- +
-| 8 bits | 2 bits | 7 bits          |
+| 8 bits | 2 bits | 6 bits          |
 
 
 ~~~~
@@ -530,7 +531,7 @@ fragment as described in {{Fig-lorawan-schc-payload}}.
 * **RuleID**: Recommended size is 8 bits in SCHC header.
 * **Window index**: encoded on W=1 bit, as per {{I-D.ietf-lpwan-ipv6-static-context-hc}}.
 * **DTag**: Size is 0 bit, not used
-* **FCN**: The FCN field is encoded on N=1 bits, so WINDOW_SIZE = 1 tile
+* **FCN**: The FCN field is encoded on N=1 bit, so WINDOW_SIZE = 1 tile
   (FCN=All-1 is reserved for SCHC).
 * **RCS calculation algorithm**: CRC32 using 0xEDB88320 (i.e. the reverse
   representation of the polynomial used e.g. in the Ethernet standard
@@ -555,7 +556,7 @@ purposes in but not SCHC needs.
 | 8 bits | 1 bit | 1 bit     | X bytes         |
 
 ~~~~
-{: #Fig-fragmentation-downlink-header-all0 title='All fragments but the last one. Header size 1 byte (8 bits), including LoraWAN FPort.'}
+{: #Fig-fragmentation-downlink-header-all0 title='All fragments but the last one. Header size 10 bits, including LoraWAN FPort.'}
 
 
 **Last fragment (All-1)**
@@ -626,13 +627,13 @@ datagram) and if the RCS is correct, the device SHALL transmit the ACK with
 the "RCS is correct" indicator bit set (C=1). This message might be lost
 therefore the SCHC gateway MAY request a retransmission of this ACK in the next
 downlink. The device SHALL keep this ACK message in memory until it receives
-a downlink, on SCHC FPortsDown from the SCHC gateway different from an
+a downlink, on SCHC FPortDown from the SCHC gateway different from an
 ACK-request: it indicates that the SCHC gateway has received the ACK message.
 
 Following the reception of a FCN=All-1 fragment (the last fragment of a
 datagram), if all fragments have been received and the RCS is not correct,
 the device SHALL transmit a Receiver-Abort fragment. The device SHALL keep
-this Abort message in memory until it receives a downlink, on SCHC FPortsDown,
+this Abort message in memory until it receives a downlink, on SCHC FPortDown,
 from the SCHC gateway different from an ACK-request indicating that the SCHC
 gateway has received the Abort message.  The fragmentation receiver (device)
 does not implement retransmission timer and inactivity timer.
@@ -663,7 +664,7 @@ MAX_ACK_REQUESTS times before aborting.
 
 Following the reception of a FCN=All-1 fragment (the last fragment of a
 datagram) and if the RCS is correct, the device SHALL transmit the ACK with the
-RCS is correct” indicator bit set. If the SCHC gateway receives this ACK, the
+"RCS is correct" indicator bit set. If the SCHC gateway receives this ACK, the
 current fragmentation session has succeeded and its context can be cleared.
 
 If the retransmission timer elapses and the SCHC gateway has not received the
@@ -689,7 +690,7 @@ RECOMMENDED value is 12 hours for both Class B and Class C end-devices.
 
 This document is only providing parameters that are expected to be better
 suited for LoRaWAN networks for {{I-D.ietf-lpwan-ipv6-static-context-hc}}. As
-such, this parameters does not contribute to any new security issues in
+such, this document does not contribute to any new security issues in
 addition of those identified in {{I-D.ietf-lpwan-ipv6-static-context-hc}}.
 
 # Acknowledgements
@@ -750,8 +751,8 @@ going through SCHC, no fragmentation required
 ~~~~
 
 An applicative payload of 78 bytes is passed to SCHC compression layer
-using rule 1, allowing to compress it to 40 bytes and 5 bits: 1 byte ruleId,
-21 bits residue + 37 bytes payload.
+using rule 1, allowing to compress it to 40 bytes and 5 bits: 1 byte
+ruleID, 21 bits residue + 37 bytes payload.
 
 
 | RuleID | Compression residue |  Payload  | Padding=b'000 |
@@ -764,11 +765,12 @@ LoRaWAN protocol: 49 bytes are available for SCHC payload; no need for
 fragmentation. The payload will be transmitted through FPort = 1
 
 
-| LoRaWAN Header                      | LoRaWAN payload (40 bytes)                      |
-+ ----------------------------------- + ----------------------------------------------- +
-|                |  FOpts  | RuleID=1 | Compression residue |  Payload  | Padding=b'000 |
-+ -------------- + ------- + -------- + ------------------- + --------- + ------------- +
-|       XXXX     | 2 bytes | 1 byte   |       21 bits       |  37 bytes |    3 bits     |
+| LoRaWAN Header            | LoRaWAN payload (40 bytes)              |
++ ------------------------- + --------------------------------------- +
+|      |  FOpts  | RuleID=1 | Compression | Payload   | Padding=b'000 |
+|      |         |          | residue     |           |               |
++ ---- + ------- + -------- + ----------- + --------- + ------------- +
+| XXXX | 2 bytes | 1 byte   | 21 bits     |  37 bytes |    3 bits     |
 
 ~~~~
 {: #Fig-example-uplink-no-fragmentation title='Uplink example: compression without fragmentation'}
@@ -781,8 +783,8 @@ going through SCHC, with fragmentation.
 ~~~~
 
 An applicative payload of 478 bytes is passed to SCHC compression layer
-using rule 1, allowing to compress it to 282 bytes and 5 bits: 1 byte ruleId,
-21 bits residue + 279 bytes payload.
+using rule 1, allowing to compress it to 282 bytes and 5 bits: 1 byte
+ruleID, 21 bits residue + 279 bytes payload.
 
 
 | RuleID | Compression residue |  Payload  |
@@ -791,8 +793,9 @@ using rule 1, allowing to compress it to 282 bytes and 5 bits: 1 byte ruleId,
 
 
 The current LoRaWAN MTU is 11 bytes, although 2 bytes FOpts are used by
-LoRaWAN protocol: 9 bytes are available for SCHC payload + 1 byte FPort field.
-SCHC header is 2 bytes (including FPort) so 1 tile is send in first fragment.
+LoRaWAN protocol: 9 bytes are available for SCHC payload + 1 byte FPort
+field.  SCHC header is 2 bytes (including FPort) so 1 tile is send in
+first fragment.
 
 | LoRaWAN Header                        | LoRaWAN payload (6 bytes) |
 + ------------------------------------- + ------------------------- +
@@ -816,14 +819,15 @@ Next transmission MTU is 242 bytes, no FOpts. 48 tiles are transmitted:
 |       XXXX     | 1 byte     | 0   0 |   61   | 240 bytes  |
 
 
-Next transmission MTU is 242 bytes, no FOpts. All 66 remaining tiles are
-transmitted, last tile is only 2 bytes. Padding is added for the remaining 3 bits.
+Next transmission MTU is 242 bytes, no FOpts. All 8 remaining tiles are
+transmitted, last tile is only 2 bytes + 5 bits. Padding is added for
+the remaining 3 bits.
 
-| LoRaWAN Header              | LoRaWAN payload (39 bytes)                         |
-+ -------------- + -----------+ -------------------------------------------------- +
-|                | RuleID=20  |   W   |  FCN   |      8 tiles      | Padding=b'000 |
-+ -------------- + ---------- + ----- + ------ + ----------------- + ------------- +
-|       XXXX     | 1 byte     | 0   0 |   13   | 37 bytes + 5 bits |    3 bits     |
+| LoRaWAN Header    | LoRaWAN payload (39 bytes)                      |
++ ---- + -----------+ ----------------------------------------------- +
+|      | RuleID=20  | W  |  FCN   |      8 tiles      | Padding=b'000 |
++ ---- + ---------- + -- + ------ + ----------------- + ------------- +
+| XXXX | 1 byte     | 00 |   13   | 37 bytes + 5 bits |    3 bits     |
 
 
 All packets have been received by the SCHC gateway, computed RCS is
@@ -843,9 +847,9 @@ correct so the following ACK is send to the device:
 
 ~~~~
 
-An applicative payload of 443 bytes is passed to SCHC compression layer using
-rule 1, allowing to compress it to 130 bytes and 5 bits: 1 byte ruleId,
-21 bits residue + 127 bytes payload.
+An applicative payload of 443 bytes is passed to SCHC compression layer
+using rule 1, allowing to compress it to 130 bytes and 5 bits: 1 byte
+ruleId, 21 bits residue + 127 bytes payload.
 
 
 | RuleID | Compression residue |  Payload  |
@@ -853,21 +857,21 @@ rule 1, allowing to compress it to 130 bytes and 5 bits: 1 byte ruleId,
 |   1    |       21 bits       | 127 bytes |
 
 
-The current LoRaWAN MTU is 50 bytes, no FOpts are used by
-LoRaWAN protocol: 48 bytes are available for SCHC payload + FPort field => it
+The current LoRaWAN MTU is 50 bytes, no FOpts are used by LoRaWAN
+protocol: 48 bytes are available for SCHC payload + FPort field => it
 has to be fragmented.
 
 
-| LoRaWAN Header              | LoRaWAN payload (50 bytes)                    |
-+ -------------- + ---------- + --------------------------------------------- +
-|                | RuleID=21  |  W  | FCN |     1 tile     | Padding=b'000000 |
-+ -------------- + ---------- + --- + --- + -------------- + ---------------- +
-|       XXXX     | 1 byte     |  0  |  0  |    49 bytes    |      6 bits      |
+| LoRaWAN Header    | LoRaWAN payload (50 bytes)                    |
++ ---- + ---------- + --------------------------------------------- +
+|      | RuleID=21  |  W  | FCN |     1 tile     | Padding=b'000000 |
++ ---- + ---------- + --- + --- + -------------- + ---------------- +
+| XXXX | 1 byte     |  0  |  0  |    49 bytes    |      6 bits      |
 
 Content of the tile is:
 | RuleID | Compression residue |        Payload     |
 + ------ + ------------------- + ------------------ +
-|   1    |       21 bits       |  4 bytes + 3 bits  |
+|   1    |       21 bits       | 45 bytes + 3 bits  |
 
 
 The receiver answers with an SCHC ACK
@@ -882,11 +886,11 @@ The receiver answers with an SCHC ACK
 The second downlink is send, two FOpts:
 
 
-| LoRaWAN Header                        | LoRaWAN payload (48 bytes)                    |
-+ ------------------------------------- + -------------------------- + ---------------- +
-|                |  FOpts  | RuleID=21  |  W  | FCN |    1 tile      | Padding=b'000000 |
-+ -------------- + ------- + ---------- + --- + --- + -------------- + ---------------- +
-|       XXXX     | 2 bytes | 1 byte     |  1  |  0  |   47 bytes     |      6 bits      |
+| LoRaWAN Header              | LoRaWAN payload (48 bytes)            |
++ --------------------------- + ------------------ + ---------------- +
+|      |  FOpts  | RuleID=21  | W | FCN | 1 tile   | Padding=b'000000 |
++ ---- + ------- + ---------- + - + --- + -------- + ---------------- +
+| XXXX | 2 bytes | 1 byte     | 1 |  0  | 47 bytes |      6 bits      |
 
 
 The receiver answers with an SCHC ACK
@@ -901,11 +905,11 @@ The receiver answers with an SCHC ACK
 The last downlink is send, no FOpts:
 
 
-| LoRaWAN Header              | LoRaWAN payload (33 bytes)                       |
-+ -------------- + ---------- + ------------------------------------------------ +
-|                | RuleID=21  |  W  | FCN |     1 tile             | Padding=b'0 |
-+ -------------- + ---------- + --- + --- + ---------------------- + ----------- +
-|       XXXX     | 1 byte     |  0  |  1  |    32 bytes + 5 bits   | 1 bit       |
+| LoRaWAN Header    | LoRaWAN payload (33 bytes)                      |
++ ---- + ---------- + ----------------------------------------------- +
+|      | RuleID=21  |  W  | FCN |    1 tile             | Padding=b'0 |
++ ---- + ---------- + --- + --- + --------------------- + ----------- +
+| XXXX | 1 byte     |  0  |  1  |   32 bytes + 5 bits   | 1 bit       |
 
 
 The receiver answers with an SCHC ACK

--- a/draft-ietf-lpwan-schc-over-lorawan.md
+++ b/draft-ietf-lpwan-schc-over-lorawan.md
@@ -522,7 +522,7 @@ LoRaWAN payload. MTU is: _4 windows * 127 tiles * 3 bytes per tile = 1524 bytes_
 In that case the device is the fragmentation receiver, and the SCHC gateway the
 fragmentation transmitter. The following fields are common to all devices.
 SCHC F/R MUST concatenate FPort and LoRaWAN payload to retrieve the SCHC
-fragment as described in {{Fig-frag-schc-fragment}}.
+fragment as described in {{Fig-lorawan-schc-payload}}.
 
 * **SCHC fragmentation reliability mode**: ACK-Always.
 * **RuleID**: size is 8 bits in SCHC header.


### PR DESCRIPTION
Based on @jca-klk proposition #12 without data in FPort. For that:

- Uplink dtag have been removed
- Uplinks tiles are now on 5 bytes.