### PR TITLE
Clarifications following Martin Duke and shepherd comments

### DIFF
--- a/draft-ietf-lpwan-schc-over-lorawan.md
+++ b/draft-ietf-lpwan-schc-over-lorawan.md
@@ -583,11 +583,11 @@ part of the rule context.
 
 ~~~~
 
-| FPort  | LoRaWAN payload                             |
-+ ------ + ------------------------------------------- +
-| RuleID |   W    | FCN=All-1 |  RCS    |  Last tile   |
-+ ------ + ------ + --------- + ------- + ------------ +
-| 8 bits | 2 bits | 6 bits    | 32 bits | 1 to 80 bits |
+| FPort  | LoRaWAN payload                                            |
++ ------ + ---------------------------------------------------------- +
+| RuleID |   W    | FCN=All-1 |  RCS    |  Last tile   | Opt. padding |
++ ------ + ------ + --------- + ------- + ------------ + ------------ +
+| 8 bits | 2 bits |  6 bits   | 32 bits | 1 to 80 bits | 0 to 7 bits  |
 
 ~~~~
 {: #Fig-fragmentation-header-all1-last-tile title='All-1 SCHC Message: the last fragment with last tile.'}

--- a/draft-ietf-lpwan-schc-over-lorawan.md
+++ b/draft-ietf-lpwan-schc-over-lorawan.md
@@ -596,15 +596,26 @@ part of the rule context.
 
 ~~~~
 
+| FPort  | LoRaWAN payload           |
++ ------ + --------------------------+
+| RuleID |   W   | C = 1 |  padding  |
+|        |       |       | (b'00000) |
++ ------ + ----- + ----- + --------- +
+| 8 bits | 2 bit | 1 bit |  5 bits   |
+
+~~~~
+{: #Fig-frag-header-long-schc-ack-rcs-ok title='SCHC ACK format, correct RCS check.'}
+
+~~~~
 | FPort  | LoRaWAN payload                                      |
 + ------ + --------------------------------- + ---------------- +
-| RuleID |   W   |   C   | Compressed bitmap | Optional padding |
+| RuleID |   W   | C = 0 | Compressed bitmap | Optional padding |
 |        |       |       |      (C = 0)      |    (b'0...0)     |
 + ------ + ----- + ----- + ----------------- + ---------------- +
 | 8 bits | 2 bit | 1 bit |    5 to 63 bits   |  0, 6 or 7 bits  |
 
 ~~~~
-{: #Fig-fragmentation-header-long-schc-ack title='SCHC ACK format, failed RCS check.'}
+{: #Fig-frag-header-long-schc-ack-rcs-fail title='SCHC ACK format, failed RCS check.'}
 
 
 Note: Because of the bitmap compression mechanism and L2 byte alignment, only

--- a/draft-ietf-lpwan-schc-over-lorawan.md
+++ b/draft-ietf-lpwan-schc-over-lorawan.md
@@ -756,7 +756,7 @@ INACTIVITY_TIMER/(MAX_ACK_REQUESTS + 1).
 
 **SCHC All-0 (FCN=0)**
 All fragments but the last have an FCN=0 (because window size is 1).  Following
-it, the device MUST transmit the SCHC ACK message. It MUST transmit up to
+an All-0 SCHC Fragment, the device MUST transmit the SCHC ACK message. It MUST transmit up to
 MAX_ACK_REQUESTS SCHC ACK messages before aborting.  In order to progress the
 fragmented datagram, the SCHC layer should immediately queue for transmission
 those SCHC ACK if no SCHC downlink have been received during RX1 and RX2 window.

--- a/draft-ietf-lpwan-schc-over-lorawan.md
+++ b/draft-ietf-lpwan-schc-over-lorawan.md
@@ -363,20 +363,20 @@ reception window.
 
 ## LoRaWAN FPort and RuleID {#lorawan-schc-payload}
 
-The FPort field is part of the SCHC Packet, as shown in
+The FPort field is part of the SCHC Message, as shown in
 {{Fig-lorawan-schc-payload}}. The SCHC C/D and the SCHC F/R SHALL concatenate
-the FPort field with the LoRaWAN payload to recompose the SCHC Packet.
-LoRaWAN payload is composed of the potential compression residue and
-the payload from the original packet.
+the FPort field with the LoRaWAN payload to recompose the SCHC Message.
 
 ~~~~
 
 | FPort | LoRaWAN payload  |
 + ------------------------ +
-|       SCHC packet        |
+|       SCHC Message       |
 
 ~~~~
-{: #Fig-lorawan-schc-payload title='SCHC Packet in LoRaWAN'}
+{: #Fig-lorawan-schc-payload title='SCHC Message in LoRaWAN'}
+
+Note: SCHC Message is any datagram send by SCHC C/D or F/R layers.
 
 A fragmented datagram with application payload transferred from device to
 Network Gateway, is called uplink fragmented datagram. It uses an FPort for data uplink

--- a/draft-ietf-lpwan-schc-over-lorawan.md
+++ b/draft-ietf-lpwan-schc-over-lorawan.md
@@ -544,6 +544,8 @@ end of each window instead of waiting until the end of all windows:
 tiles from the next window. If the SCHC ACK is not received, it SHOULD send a SCHC
 ACK REQ up to MAX_ACK_REQUESTS times, as described previously.
 
+This will avoid useless uplinks if the device has lost network coverage.
+
 For non-battery powered devices, the SCHC receiver MAY also choose to send a SCHC
 ACK only at the end of all windows. This will reduce downlink load on the LoRaWAN
 network, by reducing the number of downlinks.

--- a/draft-ietf-lpwan-schc-over-lorawan.md
+++ b/draft-ietf-lpwan-schc-over-lorawan.md
@@ -111,9 +111,9 @@ all other definitions, please look up the SCHC specification
 - OUI: Organisation Unique Identifier. IEEE assigned prefix for EUI.
 - RCS: Reassembly Check Sequence. Used to verify the integrity of the
   fragmentation-reassembly process.
-- RX: Device's reception window following an uplink.
-- RX1/RX2: LoRaWAN devices must open two RX windows following an uplink,
-  called RX1 and RX2.
+- RX: Device's reception window.
+- RX1/RX2: LoRaWAN class A devices open two RX windows following an
+  uplink, called RX1 and RX2.
 - SCHC gateway: It corresponds to the LoRaWAN Application Server. It manages
   translation between IPv6 network and the Network Gateway (LoRaWAN Network
   Server).

--- a/draft-ietf-lpwan-schc-over-lorawan.md
+++ b/draft-ietf-lpwan-schc-over-lorawan.md
@@ -359,9 +359,11 @@ reception window.
 
 ## LoRaWAN FPort and RuleID {#lorawan-schc-payload}
 
-The FPort field is part of the SCHC Message, as shown in
+The FPort field is part of the SCHC Packet, as shown in
 {{Fig-lorawan-schc-payload}}. The SCHC C/D and the SCHC F/R SHALL concatenate
-the FPort field with the LoRaWAN payload to recompose the SCHC Message.
+the FPort field with the LoRaWAN payload to recompose the SCHC Packet.
+LoRaWAN payload is composed of the potential compression residue and
+the payload from the original packet.
 
 ~~~~
 
@@ -370,7 +372,7 @@ the FPort field with the LoRaWAN payload to recompose the SCHC Message.
 |       SCHC packet        |
 
 ~~~~
-{: #Fig-lorawan-schc-payload title='SCHC Message in LoRaWAN'}
+{: #Fig-lorawan-schc-payload title='SCHC Packet in LoRaWAN'}
 
 A fragmented datagram with application payload transferred from device to
 Network Gateway, is called uplink fragmented datagram. It uses an FPort for data uplink

--- a/draft-ietf-lpwan-schc-over-lorawan.md
+++ b/draft-ietf-lpwan-schc-over-lorawan.md
@@ -709,11 +709,11 @@ purposes but not SCHC needs.
 
 ~~~~
 
-| FPort  | LoRaWAN payload                                 |
-+ ------ + --------------------------- + ----------------- +
-| RuleID | W     | FCN = b'1 | RCS     |      Payload      |
-+ ------ + ----- + --------- + ------- + ----------------- +
-| 8 bits | 1 bit | 1 bit     | 32 bits | 6 bits to X bytes |
+| FPort  | LoRaWAN payload                                         |
++ ------ + --------------------------- + ------------------------- +
+| RuleID | W     | FCN = b'1 |   RCS   |   Payload   | Opt padding |
++ ------ + ----- + --------- + ------- + ----------- + ----------- +
+| 8 bits | 1 bit | 1 bit     | 32 bits | 6 to X bits | 0 to 7 bits |
 
 ~~~~
 {: #Fig-fragmentation-downlink-header-all1 title='All-1 SCHC Message: the last fragment.'}

--- a/draft-ietf-lpwan-schc-over-lorawan.md
+++ b/draft-ietf-lpwan-schc-over-lorawan.md
@@ -376,7 +376,7 @@ the FPort field with the LoRaWAN payload to recompose the SCHC Message.
 ~~~~
 {: #Fig-lorawan-schc-payload title='SCHC Message in LoRaWAN'}
 
-Note: SCHC Message is any datagram send by SCHC C/D or F/R layers.
+Note: SCHC Message is any datagram sent by SCHC C/D or F/R layers.
 
 A fragmented datagram with application payload transferred from device to
 Network Gateway, is called uplink fragmented datagram. It uses an FPort for data uplink

--- a/draft-ietf-lpwan-schc-over-lorawan.md
+++ b/draft-ietf-lpwan-schc-over-lorawan.md
@@ -107,9 +107,13 @@ all other definitions, please look up the SCHC specification
 - Downlink: LoRaWAN term for a frame transmitted by the network and
   received by the device.
 - FRMPayload: Application data in a LoRaWAN frame.
+- MSB: Most Significant Byte
 - OUI: Organisation Unique Identifier. IEEE assigned prefix for EUI.
 - RCS: Reassembly Check Sequence. Used to verify the integrity of the
   fragmentation-reassembly process.
+- RX: Device's reception window following an uplink.
+- RX1/RX2: LoRaWAN devices must open two RX windows following an uplink,
+  called RX1 and RX2.
 - SCHC gateway: It corresponds to the LoRaWAN Application Server. It manages
   translation between IPv6 network and the Network Gateway (LoRaWAN Network
   Server).

--- a/draft-ietf-lpwan-schc-over-lorawan.md
+++ b/draft-ietf-lpwan-schc-over-lorawan.md
@@ -729,8 +729,19 @@ purposes but not SCHC needs.
 | 8 bits | 1 bit | 1 bit   | 6 bits           |
 
 ~~~~
-{: #Fig-fragmentation-downlink-header-schc-ack title='SCHC ACK format, RCS is correct.'}
+{: #Fig-frag-downlink-header-schc-ack-rcs-ok title='SCHC ACK format, RCS is correct.'}
 
+
+~~~~
+
+| FPort  | LoRaWAN payload                                   |
++ ------ + ------------------------------------------------- +
+| RuleID | W     | C = b'0 | Bitmap = b'1 | Padding b'000000 |
++ ------ + ----- + ------- + ------------ + ---------------- +
+| 8 bits | 1 bit | 1 bit   |    1 bit     |      5 bits      |
+
+~~~~
+{: #Fig-frag-downlink-header-schc-ack-rcs-fail title='SCHC ACK format, RCS is incorrect.'}
 
 #### Receiver-Abort
 


### PR DESCRIPTION
Hey @ivajloip @jca-klk 

Could you please review the changes ?
There will be one last change as Dominique discussed commit 78ee6f8 . I proposed to update the section to the following but I am waiting for his acknowledgment

```
The FPort field is part of the SCHC Message, as shown in
{{Fig-lorawan-schc-payload}}. The SCHC C/D and the SCHC F/R SHALL concatenate
the FPort field with the LoRaWAN payload to recompose the SCHC Message.

~~~~

| FPort | LoRaWAN payload  |
+ ------------------------ +
|       SCHC Message       |

~~~~
{: #Fig-lorawan-schc-payload title='SCHC Message in LoRaWAN'}

Note: SCHC Message is any datagram send by SCHC C/D or F/R layers.
```

Anyway we can start the review now as cut off date is soon.